### PR TITLE
[HOTFIX] companyId에 따라 분리된 주문->배송 생성요청 이벤트에 대한 리팩토링 진행

### DIFF
--- a/src/main/java/com/ezmeal/shipment/application/service/ShipmentApplicationService.java
+++ b/src/main/java/com/ezmeal/shipment/application/service/ShipmentApplicationService.java
@@ -1,5 +1,6 @@
 package com.ezmeal.shipment.application.service;
 
+import com.ezmeal.common.enums.Role;
 import com.ezmeal.common.exception.types.BadRequestException;
 import com.ezmeal.common.exception.types.ForbiddenException;
 import com.ezmeal.common.exception.types.NotFoundException;
@@ -17,6 +18,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -26,19 +28,38 @@ public class ShipmentApplicationService {
     private final ShipmentRepository shipmentRepository;
     private final ShipmentEventProducer shipmentEventProducer;
 
+    // orderId 기준 전체 조회 - 업체별로 Shipment가 N개일 수 있음
     @Transactional(readOnly = true)
-    public ShipmentResponse getShipment(UUID orderId, String requestCompanyId) {
+    public List<ShipmentResponse> getShipmentsByOrderId(UUID orderId, String requestCompanyId) {
         CustomUserPrincipal principal = getCurrentUser();
-        Shipment shipment = findByOrderIdOrThrow(orderId);
-        UserRoleCheck.checkReadPermission(principal.getRole(), principal.getUserId(), requestCompanyId, shipment);
-        return ShipmentResponse.from(shipment);
+        List<Shipment> shipments = shipmentRepository.findAllByOrderId(orderId);
+        if (shipments.isEmpty()) {
+            throw new NotFoundException(ShipmentErrorCode.SHIPMENT_NOT_FOUND);
+        }
+
+        Role role = principal.getRole();
+        if (role == Role.ADMIN) {
+            return shipments.stream().map(ShipmentResponse::from).toList();
+        }
+        if (role == Role.USER) {
+            UserRoleCheck.checkReadPermission(role, principal.getUserId(), requestCompanyId, shipments.get(0));
+            return shipments.stream().map(ShipmentResponse::from).toList();
+        }
+        if (role == Role.COMPANY) {
+            UUID companyId = UUID.fromString(requestCompanyId);
+            return shipments.stream()
+                    .filter(s -> s.getCompanyId().equals(companyId))
+                    .map(ShipmentResponse::from)
+                    .toList();
+        }
+        throw new ForbiddenException(ShipmentErrorCode.ACCESS_DENIED);
     }
 
     @Transactional
-    public ShipmentResponse startShipment(UUID orderId, ShipmentStartRequest request,
+    public ShipmentResponse startShipment(UUID shipmentId, ShipmentStartRequest request,
                                           String requestCompanyId) {
         CustomUserPrincipal principal = getCurrentUser();
-        Shipment shipment = findByOrderIdOrThrow(orderId);
+        Shipment shipment = findByShipmentIdOrThrow(shipmentId);
         UserRoleCheck.checkVendorOrMasterPermission(principal.getRole(), requestCompanyId, shipment);
 
         if (request.trackingNumber() == null || request.trackingNumber().isBlank()) {
@@ -57,9 +78,9 @@ public class ShipmentApplicationService {
     }
 
     @Transactional
-    public ShipmentResponse deliverShipment(UUID orderId, String requestCompanyId) {
+    public ShipmentResponse deliverShipment(UUID shipmentId, String requestCompanyId) {
         CustomUserPrincipal principal = getCurrentUser();
-        Shipment shipment = findByOrderIdOrThrow(orderId);
+        Shipment shipment = findByShipmentIdOrThrow(shipmentId);
         UserRoleCheck.checkVendorOrMasterPermission(principal.getRole(), requestCompanyId, shipment);
 
         try {
@@ -74,9 +95,9 @@ public class ShipmentApplicationService {
     }
 
     @Transactional
-    public ShipmentResponse cancelShipment(UUID orderId, String requestCompanyId) {
+    public ShipmentResponse cancelShipment(UUID shipmentId, String requestCompanyId) {
         CustomUserPrincipal principal = getCurrentUser();
-        Shipment shipment = findByOrderIdOrThrow(orderId);
+        Shipment shipment = findByShipmentIdOrThrow(shipmentId);
         UserRoleCheck.checkVendorOrMasterPermission(principal.getRole(), requestCompanyId, shipment);
 
         try {
@@ -91,15 +112,14 @@ public class ShipmentApplicationService {
 
     private CustomUserPrincipal getCurrentUser() {
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-        // principal 객체가 정의한 CustomUserPrincipal 의 타입이라면 principal이라는 변수명으로 저장
         if (auth == null || !(auth.getPrincipal() instanceof CustomUserPrincipal principal)) {
             throw new ForbiddenException(ShipmentErrorCode.ACCESS_DENIED);
         }
         return principal;
     }
 
-    private Shipment findByOrderIdOrThrow(UUID orderId) {
-        return shipmentRepository.findByOrderId(orderId)
-            .orElseThrow(() -> new NotFoundException(ShipmentErrorCode.SHIPMENT_NOT_FOUND));
+    private Shipment findByShipmentIdOrThrow(UUID shipmentId) {
+        return shipmentRepository.findById(shipmentId)
+                .orElseThrow(() -> new NotFoundException(ShipmentErrorCode.SHIPMENT_NOT_FOUND));
     }
 }

--- a/src/main/java/com/ezmeal/shipment/domain/entity/Shipment.java
+++ b/src/main/java/com/ezmeal/shipment/domain/entity/Shipment.java
@@ -20,7 +20,7 @@ public class Shipment extends BaseEntity {
     @Column(columnDefinition = "uuid")
     private UUID id;
 
-    @Column(name = "order_id", nullable = false, unique = true, columnDefinition = "uuid")
+    @Column(name = "order_id", nullable = false, columnDefinition = "uuid")
     private UUID orderId;
 
     @Column(name = "user_id", nullable = false, columnDefinition = "uuid")

--- a/src/main/java/com/ezmeal/shipment/domain/repository/ShipmentRepository.java
+++ b/src/main/java/com/ezmeal/shipment/domain/repository/ShipmentRepository.java
@@ -2,10 +2,13 @@ package com.ezmeal.shipment.domain.repository;
 
 import com.ezmeal.shipment.domain.entity.Shipment;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 public interface ShipmentRepository {
     Shipment save(Shipment shipment);
+    Optional<Shipment> findById(UUID shipmentId);
     Optional<Shipment> findByOrderId(UUID orderId);
+    List<Shipment> findAllByOrderId(UUID orderId);
 }

--- a/src/main/java/com/ezmeal/shipment/infrastructure/messaging/kafka/consumer/OrderEventConsumerImpl.java
+++ b/src/main/java/com/ezmeal/shipment/infrastructure/messaging/kafka/consumer/OrderEventConsumerImpl.java
@@ -34,19 +34,19 @@ public class OrderEventConsumerImpl implements OrderEventConsumer {
     }
 
     /**
-     * order.cancelled 수신 → PREPARING 상태이면 CANCELLED 로 변경
+     * order.cancelled 수신 → PREPARING 상태인 모든 Shipment를 CANCELLED 로 변경
      */
     @KafkaListener(topics = "order.cancelled", groupId = "${spring.kafka.consumer.group-id}")
     public void onOrderCancelled(EventEnvelope<OrderCancelledPayload> envelope) {
         inboxProcessor.processOnce(envelope.eventId(), () -> {
             OrderCancelledPayload payload = envelope.payload();
-            shipmentRepository.findByOrderId(payload.orderId()).ifPresent(shipment -> {
+            shipmentRepository.findAllByOrderId(payload.orderId()).forEach(shipment -> {
                 try {
                     shipment.cancel();
                     shipmentRepository.save(shipment);
-                    log.info("[Kafka] Shipment 취소 처리 완료: orderId={}", payload.orderId());
+                    log.info("[Kafka] Shipment 취소 처리 완료: orderId={}, shipmentId={}", payload.orderId(), shipment.getId());
                 } catch (IllegalStateException e) {
-                    log.warn("[Kafka] Shipment 취소 불가 (이미 배송 시작): orderId={}", payload.orderId());
+                    log.warn("[Kafka] Shipment 취소 불가 (이미 배송 시작): orderId={}, shipmentId={}", payload.orderId(), shipment.getId());
                 }
             });
         });

--- a/src/main/java/com/ezmeal/shipment/infrastructure/persistence/JpaShipmentRepository.java
+++ b/src/main/java/com/ezmeal/shipment/infrastructure/persistence/JpaShipmentRepository.java
@@ -3,9 +3,11 @@ package com.ezmeal.shipment.infrastructure.persistence;
 import com.ezmeal.shipment.domain.entity.Shipment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 public interface JpaShipmentRepository extends JpaRepository<Shipment, UUID> {
     Optional<Shipment> findByOrderId(UUID orderId);
+    List<Shipment> findAllByOrderId(UUID orderId);
 }

--- a/src/main/java/com/ezmeal/shipment/infrastructure/persistence/ShipmentRepositoryImpl.java
+++ b/src/main/java/com/ezmeal/shipment/infrastructure/persistence/ShipmentRepositoryImpl.java
@@ -5,6 +5,7 @@ import com.ezmeal.shipment.domain.repository.ShipmentRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -20,7 +21,17 @@ public class ShipmentRepositoryImpl implements ShipmentRepository {
     }
 
     @Override
+    public Optional<Shipment> findById(UUID shipmentId) {
+        return jpaShipmentRepository.findById(shipmentId);
+    }
+
+    @Override
     public Optional<Shipment> findByOrderId(UUID orderId) {
         return jpaShipmentRepository.findByOrderId(orderId);
+    }
+
+    @Override
+    public List<Shipment> findAllByOrderId(UUID orderId) {
+        return jpaShipmentRepository.findAllByOrderId(orderId);
     }
 }

--- a/src/main/java/com/ezmeal/shipment/presentation/controller/ShipmentController.java
+++ b/src/main/java/com/ezmeal/shipment/presentation/controller/ShipmentController.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.UUID;
 
 @RestController
@@ -16,41 +17,44 @@ public class ShipmentController {
 
     private final ShipmentApplicationService shipmentApplicationService;
 
+    // orderId 기준 조회 → 업체별 Shipment 목록 반환
     @GetMapping("/api/v1/shipments/{orderId}")
-    public ResponseEntity<CommonApiResponse<ShipmentResponse>> getShipment(
+    public ResponseEntity<CommonApiResponse<List<ShipmentResponse>>> getShipment(
         @PathVariable UUID orderId,
         @RequestHeader(value = "X-Company-Id", required = false) String companyId
     ) {
-        ShipmentResponse data = shipmentApplicationService.getShipment(orderId, companyId);
+        List<ShipmentResponse> data = shipmentApplicationService.getShipmentsByOrderId(orderId, companyId);
         return ResponseEntity.ok(CommonApiResponse.success("배송 상태 조회 성공", data));
     }
 
-    @PatchMapping("/api/v1/shipments/{orderId}/start")
+    // 특정 Shipment 배송 시작 (shipmentId 기준)
+    @PatchMapping("/api/v1/shipments/{shipmentId}/start")
     public ResponseEntity<CommonApiResponse<ShipmentResponse>> startShipment(
-        @PathVariable UUID orderId,
+        @PathVariable UUID shipmentId,
         @RequestBody ShipmentStartRequest request,
         @RequestHeader(value = "X-Company-Id", required = false) String companyId
     ) {
-        ShipmentResponse data = shipmentApplicationService.startShipment(orderId, request, companyId);
+        ShipmentResponse data = shipmentApplicationService.startShipment(shipmentId, request, companyId);
         return ResponseEntity.ok(CommonApiResponse.success("배송이 시작되었습니다.", data));
     }
 
-    @PatchMapping("/api/v1/shipments/{orderId}/delivered")
+    // 특정 Shipment 배송 완료 (shipmentId 기준)
+    @PatchMapping("/api/v1/shipments/{shipmentId}/delivered")
     public ResponseEntity<CommonApiResponse<ShipmentResponse>> deliverShipment(
-        @PathVariable UUID orderId,
+        @PathVariable UUID shipmentId,
         @RequestHeader(value = "X-Company-Id", required = false) String companyId
     ) {
-        ShipmentResponse data = shipmentApplicationService.deliverShipment(orderId, companyId);
+        ShipmentResponse data = shipmentApplicationService.deliverShipment(shipmentId, companyId);
         return ResponseEntity.ok(CommonApiResponse.success("배송이 완료되었습니다.", data));
     }
 
-    // API 스펙 원문: /api/v1/shipment/{orderId}/cancel (단수)
-    @PatchMapping("/api/v1/shipments/{orderId}/cancel")
+    // 특정 Shipment 배송 취소 (shipmentId 기준)
+    @PatchMapping("/api/v1/shipments/{shipmentId}/cancel")
     public ResponseEntity<CommonApiResponse<ShipmentResponse>> cancelShipment(
-        @PathVariable UUID orderId,
+        @PathVariable UUID shipmentId,
         @RequestHeader(value = "X-Company-Id", required = false) String companyId
     ) {
-        ShipmentResponse data = shipmentApplicationService.cancelShipment(orderId, companyId);
+        ShipmentResponse data = shipmentApplicationService.cancelShipment(shipmentId, companyId);
         return ResponseEntity.ok(CommonApiResponse.success("배송이 취소되었습니다.", data));
     }
 }


### PR DESCRIPTION
## 🔗 Issue Number
- close #13 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **API 변경**
  * 배송 조회 응답이 단일 배송에서 여러 배송 목록으로 변경됨
  * 배송 시작/완료/취소 작업의 API 경로가 주문 ID에서 배송 ID 기반으로 변경됨
  * 주문당 여러 배송을 관리할 수 있도록 데이터 구조 개선됨

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2ZMeal/Shipment_server/pull/14?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->